### PR TITLE
Allow API token to be set via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,16 @@ sudo easy_install pip
 ----------------
 Create a file `.poeditor` in the root of your project.
 
-Example:
+
+**Note:** For security reasons it's recommended that you use the environment variables to store you API key:
+```
+export POEDITOR_TOKEN=54df54gd5f4gs5sdfsdfsdfasdfsdfasdfasdf
+```
+
+**Example:**
 ```
 [main]
-apikey = 54df54gd5f4gs5sdfsdfsdfasdfsdfasdfasdf
+apikey = 54df54gd5f4gs5sdfsdfsdfasdfsdfasdfasdf; **Note:** Use the POEDITOR_TOKEN instead
 
 [project.vikingapp_be]
 project_id = 4200
@@ -36,6 +42,7 @@ trans.en = App/src/main/res/values/strings.xml
 trans.nl = App/src/main/res/values-nl/strings.xml
 trans.fr = App/src/main/res/values-fr/strings.xml
 ```
+
 
 Parameter       | Description
 --------------- | ----------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ sudo easy_install pip
 Create a file `.poeditor` in the root of your project.
 
 
-**Note:** For security reasons it's recommended that you use the environment variables to store you API key:
+**Note:** For security reasons it's recommended that you use the `POEDITOR_TOKEN` 
+environment variables to store you API key:
 ```
 export POEDITOR_TOKEN=54df54gd5f4gs5sdfsdfsdfasdfsdfasdfasdf
 ```
@@ -41,15 +42,23 @@ terms = App/src/main/res/values/strings.xml
 trans.en = App/src/main/res/values/strings.xml
 trans.nl = App/src/main/res/values-nl/strings.xml
 trans.fr = App/src/main/res/values-fr/strings.xml
+
+[project.cat_pictures]
+project_id = 4201
+type = json
+terms = App/src/main/res/values/strings.json
+trans.en = App/src/main/res/values/strings.json
+trans.nl = App/src/main/res/values-nl/strings.json
+trans.fr = App/src/main/res/values-fr/strings.json
 ```
 
 
-Parameter       | Description
---------------- | ----------------------------------------------------------------------
-apikey          | go to [My Account > API Access](https://poeditor.com/account/api)
-project_id      | id of the translation project, can be found under *API Access* as well
-type            | file format  (po, pot, mo, xls, apple_strings, xliff, android_strings, resx, resw, properties, json) , cfr [export](https://poeditor.com/api_reference/#export)
-trans.*locale*  | which language that you want to download and where to store it
+Parameter                                         | Description
+------------------------------------------------- | ----------------------------------------------------------------------
+apikey (or `POEDITOR_TOKEN` environment variable) | go to [My Account > API Access](https://poeditor.com/account/api)
+project_id                                        | id of the translation project, can be found under *API Access* as well
+type                                              | file format  (po, pot, mo, xls, apple_strings, xliff, android_strings, resx, resw, properties, json) , cfr [export](https://poeditor.com/api_reference/#export)
+trans.*locale*                                    | which language that you want to download and where to store it
 
 3. Usage
 --------

--- a/poeditor_client/cmd.py
+++ b/poeditor_client/cmd.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+from time import sleep
 
 from ConfigParser import NoOptionError, NoSectionError, SafeConfigParser
 from poeditor import POEditorAPI, POEditorException
@@ -163,9 +164,10 @@ def push(config, languages=None, overwrite=False, sync_terms=False):
                     overwrite=overwrite,
                     sync_terms=sync_terms
                 )
+                sleep(10.5)  # Avoids API rate limit
 
 
-def pushTerms(config):
+def pushTerms(config, sync_terms=False):
     """
     Pushes new terms to POEditor
     """
@@ -179,7 +181,8 @@ def pushTerms(config):
             if terms:
                 project_id = config.get(s, "project_id")
                 print(" - Project: {0}, {1}\n".format(s, terms))
-                client.update_terms(project_id, terms)
+                client.update_terms(project_id, terms, sync_terms=sync_terms)
+                sleep(10.5)  # Avoids API rate limit
 
 
 def status(config):
@@ -246,7 +249,7 @@ def main():
 
     elif "pushTerms" == args.command:
         print("Push terms")
-        pushTerms(config)
+        pushTerms(config, sync_terms=args.sync_terms)
 
     elif "status" == args.command:
         status(config)

--- a/poeditor_client/cmd.py
+++ b/poeditor_client/cmd.py
@@ -1,10 +1,21 @@
 import argparse
 import os
 
-from ConfigParser import SafeConfigParser
+from ConfigParser import NoOptionError, NoSectionError, SafeConfigParser
 from poeditor import POEditorAPI, POEditorException
 
 FILENAME = ".poeditor"
+
+
+def _get_api_token(config):
+    """
+    Get the API key either from the config file or the environment variables.
+    """
+    assert config
+    try:
+        return config.get("main", "apikey")
+    except (NoOptionError, NoSectionError):
+        return os.environ.get('POEDITOR_TOKEN')
 
 
 def _load_config(path):
@@ -51,7 +62,7 @@ def init(config):
     Initializes the project on POEditor based on the configuration file.
     """
     assert config
-    client = POEditorAPI(api_token=config.get("main", "apikey"))
+    client = POEditorAPI(api_token=_get_api_token(config))
     sections = config.sections()
 
     for s in sections:
@@ -91,7 +102,7 @@ def pull(config, languages=None):
     Pulls translations from the POEditor API.
     """
     assert config
-    client = POEditorAPI(api_token=config.get("main", "apikey"))
+    client = POEditorAPI(api_token=_get_api_token(config))
     sections = config.sections()
 
     for s in sections:
@@ -121,7 +132,7 @@ def push(config, languages=None, overwrite=False, sync_terms=False):
     Push terms and languages
     """
     assert config
-    client = POEditorAPI(api_token=config.get("main", "apikey"))
+    client = POEditorAPI(api_token=_get_api_token(config))
     sections = config.sections()
 
     for section in sections:
@@ -159,7 +170,7 @@ def pushTerms(config):
     Pushes new terms to POEditor
     """
     assert config
-    client = POEditorAPI(api_token=config.get("main", "apikey"))
+    client = POEditorAPI(api_token=_get_api_token(config))
     sections = config.sections()
 
     for s in sections:
@@ -178,7 +189,7 @@ def status(config):
     files.
     """
     assert config
-    client = POEditorAPI(api_token=config.get("main", "apikey"))
+    client = POEditorAPI(api_token=_get_api_token(config))
     sections = config.sections()
 
     print("Api key: {}".format(config.get("main", "apikey")))


### PR DESCRIPTION
I'd like to push my `.poeditor` on a public GitHub repo, so can't push my API key to production.

If there's a better way to do this, please let me know!