### PR TITLE
update poeditor dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     long_description=long_description,
     python_requires='>3.5.0',
     install_requires=[
-       "poeditor==1.1.0",
+       "poeditor==1.1.3",
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
To use all currently supported file types (like e.g. `.arb`) the updated version of the poeditor wrapper is needed.
See [release notes of version 1.1.3](https://github.com/sporteasy/python-poeditor/releases/tag/1.1.3)
